### PR TITLE
Update DB Class to Prevent Collisions

### DIFF
--- a/code/Field/Color.php
+++ b/code/Field/Color.php
@@ -11,7 +11,7 @@
  * @package SS_ColorField
  * @subpackage Field
  */
-class Color extends DBField
+class SS_Color extends DBField
 {
 
     /**

--- a/code/Form/ColorField.php
+++ b/code/Form/ColorField.php
@@ -121,7 +121,7 @@ class ColorField extends FormField
 
       $id = $this->ID();
 
-      $color = DBField::create_field('Color', $this->Value(), 'Color');
+      $color = DBField::create_field('SS_Color', $this->Value(), 'Color');
       $hex   = $color->Hex();
       $red   = $color->R();
       $green = $color->G();


### PR DESCRIPTION
The Database class should be updated to SS_Color. Color by itself is too generic and caused collisions with other modules (yes, they should rename their classes as well)
