### PR TITLE
number format alpha value, to replace comma

### DIFF
--- a/code/Field/Color.php
+++ b/code/Field/Color.php
@@ -188,7 +188,7 @@ class SS_Color extends DBField
    */
   public function Alpha()
   {
-      return $this->alpha;
+    return number_format($this->alpha, 2);
   }
 
   /**


### PR DESCRIPTION
Otherwise the alpha bar is reset to 0 when a localized number format dctates a comma as decimal seperator.
